### PR TITLE
Fix allow hosts to recover password

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,18 @@ services:
       - ./postgres:/data/postgres
     networks:
       - animap
+
+  pgadmin:
+    image: dpage/pgadmin4
+    ports:
+      - 5454:5454/tcp
+    environment:
+      - PGADMIN_DEFAULT_EMAIL=admin@mydomain.com
+      - PGADMIN_DEFAULT_PASSWORD=postgres
+      - PGADMIN_LISTEN_PORT=5454
+    networks:
+      - animap
+
   animap_redis_dev:
     container_name: animap_redis_dev
     image: redis

--- a/src/domain/providers/session_provider.ts
+++ b/src/domain/providers/session_provider.ts
@@ -1,4 +1,5 @@
 import { ID } from "../../core/types/id"
+import { Host } from "../entities/host_entity"
 import { User } from "../entities/user_entity"
 
 export type SessionToken = string
@@ -16,7 +17,7 @@ export interface SessionProvider {
   create: (clientId: ID, sessionType: SessionType) => Promise<SessionToken>
   destroy: (session: SessionToken) => Promise<void>
   validateToken: (sessionToken: SessionToken) => Promise<SessionData | null>
-  destroyUserSessions: (user: User | ID) => Promise<void>
+  destroySessionsFor: (client: User | Host | ID) => Promise<void>
 }
 
 export const SessionProviderToken = Symbol.for("SessionProvider")

--- a/src/infra/providers/session/redis_session_provider.ts
+++ b/src/infra/providers/session/redis_session_provider.ts
@@ -15,6 +15,7 @@ import {
 import { ApplicationError } from "../../../core/errors/application_error"
 import { RedisProvider } from "../redis/redis_provider"
 import { User } from "../../../domain/entities/user_entity"
+import { Host } from "../../../domain/entities/host_entity"
 
 const ONE_WEEK_IN_SECONDS = 604800
 
@@ -50,8 +51,8 @@ export class RedisSessionProvider implements SessionProvider {
     return sessionToken
   }
 
-  public destroyUserSessions = async (user: User | ID) => {
-    const id = typeof user === "string" ? user : user.id
+  public destroySessionsFor = async (client: User | Host | ID) => {
+    const id = typeof client === "string" ? client : client.id
     await this.redisProvider.del(this.sessionKeyFor(id))
   }
 


### PR DESCRIPTION
- Allows users and hosts to recover their passwords using their emails

Seems like having two separate entities to represent users of the system was a bad idea, we'll keep rolling with it though