### PR TITLE
Fix/cpf validator

### DIFF
--- a/src/domain/validators/cpf.ts
+++ b/src/domain/validators/cpf.ts
@@ -17,7 +17,13 @@ export const cpf = (
       options: validationOptions,
       async: false,
       validator: {
-        validate: (value: string | number) => validateBr.cpf(value),
+        validate: (value: string | number) => {
+          if (!value) {
+            return false
+          }
+
+          return validateBr.cpf(value)
+        },
       },
     })
   }

--- a/src/presentation/rest/controllers/http/host/host_controller.spec.ts
+++ b/src/presentation/rest/controllers/http/host/host_controller.spec.ts
@@ -99,22 +99,17 @@ describe("Host controller functional test suite", () => {
     expect(response.body).toEqual([{ message: "Esse cpf já está em uso" }])
   })
 
-  test("POST api/v1/hosts :: when cpf is invalid, should fail with an error message", async () => {
-    const host = await factory.build(Host)
+  test.each([["s"], [" "], ["83592353929523"], [undefined]])(
+    "POST api/v1/hosts :: when cpf is invalid, should fail with an error message",
+    async cpf => {
+      const host = await factory.build(Host, { cpf })
 
-    const overrides = [{ cpf: "s" }, { cpf: " " }, { cpf: "83592353929523" }]
+      const response = await request(app).post("/api/v1/hosts").send(host)
 
-    const responses = await Promise.all(
-      overrides
-        .map(override => ({ ...host, ...override }))
-        .map(host => request(app).post("/api/v1/hosts").send(host))
-    )
-
-    for (const response of responses) {
       expect(response.status).toBe(StatusCodes.BAD_REQUEST)
       expect(response.body).toEqual([{ message: "O cpf deve ser válido" }])
     }
-  })
+  )
 
   test("POST api/v1/hosts :: when all validation passes, should create a host account", async () => {
     const host = await factory.build(Host)


### PR DESCRIPTION
Cpf validator was crashing when cpf was not provided. 

With this changes:

- Cpf validator assumes any falsy value is not a valid cpf